### PR TITLE
Only record volumes while speaking & some es6 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "sibilant-webaudio",
+  "name": "@rifflearning/sibilant",
   "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
@@ -871,7 +871,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test": "npm test"
   },
   "dependencies": {
-    "lodash": "^4.17.20",
     "microevent": "^1.0.0"
   },
   "devDependencies": {

--- a/sibilant.js
+++ b/sibilant.js
@@ -54,14 +54,13 @@ function speakingDetectionNode (audioContext, analyser, threshold, emitter) {
     //var maxVolume = _.max(_.filter(fftBins, function (v) { return v < 0 }));
     //currentVolume = maxVolume;
     currentVolume = getMaxVolume(analyser, fftBins);
-    volumes.push({timestamp: Date.now(),
-                  vol: currentVolume});
     emitter.trigger('volumeChange', currentVolume);
     // speaking, add the date to the stack, clear quiet record
     if (currentVolume > threshold) {
       emitter.trigger('speaking');
       speakingTimes.push(new Date());
       quietHistory = [];
+      volumes.push({timestamp: Date.now(), vol: currentVolume});
     } else if (speakingTimes.length > 0) {
       if (hasStoppedSpeaking()) {
         emitter.trigger('stoppedSpeaking', {'start': _.min(speakingTimes), 'end': _.max(speakingTimes), 'volumes': volumes});
@@ -69,6 +68,7 @@ function speakingDetectionNode (audioContext, analyser, threshold, emitter) {
         speakingTimes = [];
       } else {
         quietHistory.push(new Date());
+        volumes.push({timestamp: Date.now(), vol: currentVolume});
       }
     }
   };

--- a/sibilant.js
+++ b/sibilant.js
@@ -1,5 +1,4 @@
 const microevent = require('microevent');
-const _ = require('lodash');
 
 // get audio context
 const AudioContextType = window.AudioContext || window.webkitAudioContext;
@@ -101,7 +100,6 @@ var audioContext = null;
 class Sibilant {
   constructor (stream, options) {
     options = options || {};
-    const self = this;
     this.fftSize = (options.fftSize || 512);
     this.threshold = (options.threshold || -40);
     this.smoothing = (options.smoothing || 0.2);


### PR DESCRIPTION
## Description
- We now only record volume while we are recording a speaking event. In addition, the volumes are timestamped by time since the start of the speaking event - ie, the first volume timestamp is `0`. 
- Now use let/const instead of just var
- Some changes to simplify the speech detection implementation(behavior should remain the same)
- Added some comments to the code where I thought some more clarity was useful or if what was happening was unclear to me.
 
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Volumes were previously being recorded constantly, every time the audio was processed (occurs roughly on the order of every 40ms). So, when a `stoppedSpeaking` event fired, it included all of the volumes *since the last time they spoke*. This could be tens of thousands of volume entries. Obviously, this is bad - we now only record relevant volumes. This will make data analysis easier (no need to parse through irrelevant data) and reduce storage usage significantly. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Maintenance (change which doesn't modify functionality, but provides dependency updates or tooling improvements)
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Refactor (non-breaking change which doesn't change functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

